### PR TITLE
Use default font-weight for html

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -2,7 +2,6 @@ body {
       background: #fff url('http://static.tumblr.com/ngnm44u/QkFllq9ow/sketch.gif') no-repeat 1300px 10px fixed;
       color: #404040;
       font: normal 1em/1.5em Roboto, Trebuchet MS, Arial, sans-serif;
-      font-weight:300;
       letter-spacing:1px;
         margin: 1.5em;
       padding: 0;


### PR DESCRIPTION
Yeah, I know, style preferences are a dime a dozen, but I really do find it hard to read with weight 300, and it really is easier with weight 400, which the browser defaults to.